### PR TITLE
Update AWS provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following module variables changes have occurred:
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 2.7.0 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@
  * #### Deprecations
  * - `additional_tags` - marked for deprecation as it no longer meets our standards.
  * - `resource_name`  - marked for deprecation as it no longer meets our standards.
-* - `security_group_list`  - marked for deprecation as it no longer meets our standards.
+ * - `security_group_list`  - marked for deprecation as it no longer meets our standards.
  *
  * #### Additions
  * - `tags` - introduced as a replacement for `additional_tags` to better align with our standards.
@@ -65,6 +65,10 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = ">= 2.7.0"
+  }
 }
 
 locals {
@@ -191,7 +195,7 @@ module "redshift_cpu_alarm_high" {
   ]
 }
 
-module "redshift_cluster_health_Ticket" {
+module "redshift_cluster_health_ticket" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
 
   alarm_description        = "Cluster has entered unhealthy state, creating ticket"


### PR DESCRIPTION
Update AWS provider >= to 2.7.0 and update README for new provider version as well. Update examples and tests to use the proper provider where needed.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.