### PR TITLE
Update CloudWatch Alarm module pinning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,7 @@ resource "aws_route53_record" "redshift_internal_record_set" {
 }
 
 module "redshift_cpu_alarm_high" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
 
   alarm_description        = "Alarm if ${aws_redshift_cluster.redshift_cluster.id} CPU > ${var.cw_cpu_threshold}% for 5 minutes"
   alarm_name               = "${local.name}-CPUAlarmHigh"
@@ -196,7 +196,7 @@ module "redshift_cpu_alarm_high" {
 }
 
 module "redshift_cluster_health_ticket" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
 
   alarm_description        = "Cluster has entered unhealthy state, creating ticket"
   alarm_name               = "${local.name}-CluterHealthTicket"
@@ -220,7 +220,7 @@ module "redshift_cluster_health_ticket" {
 }
 
 module "redshift_free_storage_space_ticket" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
 
   alarm_description        = "Consumed storage space has risen above threshold, sending email notification"
   alarm_name               = "${local.name}-FreeStorageSpaceTicket"


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-1622](https://jira.rax.io/browse/MPCSUPENG-1622)

##### Summary of change(s):
- Update pinning of CloudWatch Alarm module to 0.12.4

##### Reason for Change(s):

- Keep module references current

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Yes, CloudWatch Alarm module updated.

##### If input variables or output variables have changed or has been added, have you updated the README?

No

##### Do examples need to be updated based on changes?

No

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
