### PR TITLE
Ensure tests meet Redshift password requirements

### DIFF
--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -48,11 +48,14 @@ resource "random_string" "username_string" {
 }
 
 resource "random_string" "password_string" {
-  length  = 16
-  special = false
-  upper   = true
-  lower   = true
-  number  = true
+  length      = 16
+  lower       = true
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
+  number      = true
+  special     = false
+  upper       = true
 }
 
 module "redshift_test" {


### PR DESCRIPTION
##### Corresponding Issue(s):
 -[MPCSUPENG-1162](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#master_password)
##### Summary of change(s):

Updates random password resource in tests to ensure the generated string meets the [minimum requirements for Redshift password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#master_password), specifically
```
Password must contain at least 8 chars and contain at least one uppercase letter, one lowercase letter, and one number.
```
##### Reason for Change(s):

- Prevent random failures during Redshift tests
-
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No, destruction shown in test is due to the random password being updated to meet the new criteria.  No module resources were replaced or destroyed.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Not needed
##### Do examples need to be updated based on changes?
Not needed
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
